### PR TITLE
修复启动时提示ps -p提示需要参数问题

### DIFF
--- a/SOURCES/server_ctl
+++ b/SOURCES/server_ctl
@@ -126,7 +126,7 @@ backup() {
 pid=0
 check_pid() {
   pid=`ps ax | grep ${NODEJS_BIN} | grep -v grep | grep 'dispatch' | awk '{print $1}'`
-  if [ ! pid ]; then
+  if [ ! $pid ]; then
     return 0
   fi
   ps -p $pid > /dev/null


### PR DESCRIPTION
<img width="535" alt="屏幕快照 2019-10-18 下午6 18 23" src="https://user-images.githubusercontent.com/261698/67086757-10e03280-f1d4-11e9-9505-7fa301976e85.png">

缺少了$，导致判断[ ! pid ]总是为false。

另外我看https://github.com/node-honeycomb/honeycomb-server/blob/master/bin/assets/server_ctl 这里已经更新了，是不是应该用新版的替换掉这个？
